### PR TITLE
Fix DPI issues

### DIFF
--- a/ScreenGrab/Form1.cs
+++ b/ScreenGrab/Form1.cs
@@ -5,57 +5,67 @@ namespace ScreenGrab
 {
 	public partial class Form1 : Form
 	{
-		private Panel headerPanel;
-		private Button copyButton;
-		private Button saveButton;
-		private Button saveAndCopyPathButton;
+               private Panel headerPanel;
+               private Button copyButton;
+               private Button saveButton;
+               private Button saveAndCopyPathButton;
+               private readonly bool isHighDpi;
+               private readonly float scaleFactor;
 
 		private Stack<Rectangle> rectangleHistory = new Stack<Rectangle>();
 		private Stack<Rectangle> redoStack = new Stack<Rectangle>();
 
-		const int highlightThickness = 5;
-		const int highlightCornerRadius = 20;
+               private readonly int highlightThickness;
+               const int highlightCornerRadius = 20;
 
-		public Form1() : base()
-		{
-			Icon = new Icon(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "icon.ico"));
+               public Form1() : base()
+               {
+                       Icon = new Icon(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "icon.ico"));
 
-			SetStyle(
-				ControlStyles.ResizeRedraw
-			  | ControlStyles.AllPaintingInWmPaint
-			  | ControlStyles.UserPaint
-			, true);
-			DoubleBuffered = true;
+                       scaleFactor = DeviceDpi / 96f;
+                       isHighDpi = scaleFactor > 1f;
+                       highlightThickness = isHighDpi ? 5 : 2;
 
-			headerPanel = new Panel
-			{
-				Dock = DockStyle.Top,
-				Height = 60,
-				BackColor = SystemColors.ControlLight
-			};
+                       SetStyle(
+                               ControlStyles.ResizeRedraw
+                         | ControlStyles.AllPaintingInWmPaint
+                         | ControlStyles.UserPaint
+                       , true);
+                       DoubleBuffered = true;
 
-			copyButton = new Button
-			{
-				Text = "Copy",
-				Size = new Size(90, 40),
-				Location = new Point(10, 15)
-			};
-			copyButton.Click += CopyButton_Click;
+                       int headerHeight = isHighDpi ? 60 : 70;
+                       int buttonWidth = isHighDpi ? 90 : 110;
+                       int buttonHeight = isHighDpi ? 40 : 50;
 
-			saveButton = new Button
-			{
-				Text = "Save",
-				Size = new Size(90, 40),
-				Location = new Point(100, 15)
-			};
-			saveButton.Click += SaveButton_Click;
+                       headerPanel = new Panel
+                       {
+                               Dock = DockStyle.Top,
+                               Height = headerHeight,
+                               BackColor = SystemColors.ControlLight
+                       };
 
-			saveAndCopyPathButton = new Button
-			{
-				Text = "Save (copy path)",
-				Size = new Size(240, 40),
-				Location = new Point(200, 15)
-			};
+                       copyButton = new Button
+                       {
+                               Text = "Copy",
+                               Size = new Size(buttonWidth, buttonHeight),
+                               Location = new Point(10, (headerHeight - buttonHeight) / 2)
+                       };
+                       copyButton.Click += CopyButton_Click;
+
+                       saveButton = new Button
+                       {
+                               Text = "Save",
+                               Size = new Size(buttonWidth, buttonHeight),
+                               Location = new Point(100, (headerHeight - buttonHeight) / 2)
+                       };
+                       saveButton.Click += SaveButton_Click;
+
+                       saveAndCopyPathButton = new Button
+                       {
+                               Text = "Save (copy path)",
+                               Size = new Size(isHighDpi ? 240 : 260, buttonHeight),
+                               Location = new Point(200, (headerHeight - buttonHeight) / 2)
+                       };
 			saveAndCopyPathButton.Click += SaveAndCopyPathButton_Click;
 
 			headerPanel.Controls.Add(copyButton);
@@ -362,10 +372,11 @@ namespace ScreenGrab
 		{
 			if (capturedImage != null && !dragStartPoint.HasValue)
 			{
-				// Calculate button positions: center all buttons as a group
-				int gap = 10;
-				int groupWidth = copyButton.Width + saveButton.Width + saveAndCopyPathButton.Width + (gap * 2);
-				int leftStart = (ClientSize.Width - groupWidth) / 2;
+                               // Calculate button positions: center all buttons as a group
+                               int gap = 10;
+                               int groupWidth = copyButton.Width + saveButton.Width + saveAndCopyPathButton.Width + (gap * 2);
+                               int leftStart = (ClientSize.Width - groupWidth) / 2;
+                               int top = (headerPanel.Height - copyButton.Height) / 2;
 
 				copyButton.Visible = true;
 				saveButton.Visible = true;
@@ -374,9 +385,9 @@ namespace ScreenGrab
 				saveButton.BringToFront();
 				saveAndCopyPathButton.BringToFront();
 
-				copyButton.Location = new Point(leftStart, 10);
-				saveButton.Location = new Point(leftStart + copyButton.Width + gap, 10);
-				saveAndCopyPathButton.Location = new Point(leftStart + copyButton.Width + saveButton.Width + (gap * 2), 10);
+                               copyButton.Location = new Point(leftStart, top);
+                               saveButton.Location = new Point(leftStart + copyButton.Width + gap, top);
+                               saveAndCopyPathButton.Location = new Point(leftStart + copyButton.Width + saveButton.Width + (gap * 2), top);
 			}
 
 			if (e.Button == MouseButtons.Left && dragStartPoint.HasValue)

--- a/ScreenGrab/Form1.cs
+++ b/ScreenGrab/Form1.cs
@@ -5,67 +5,67 @@ namespace ScreenGrab
 {
 	public partial class Form1 : Form
 	{
-               private Panel headerPanel;
-               private Button copyButton;
-               private Button saveButton;
-               private Button saveAndCopyPathButton;
-               private readonly bool isHighDpi;
-               private readonly float scaleFactor;
+		private Panel headerPanel;
+		private Button copyButton;
+		private Button saveButton;
+		private Button saveAndCopyPathButton;
+		private readonly bool isHighDpi;
+		private readonly float scaleFactor;
 
 		private Stack<Rectangle> rectangleHistory = new Stack<Rectangle>();
 		private Stack<Rectangle> redoStack = new Stack<Rectangle>();
 
-               private readonly int highlightThickness;
-               const int highlightCornerRadius = 20;
+		private readonly int highlightThickness;
+		const int highlightCornerRadius = 20;
 
-               public Form1() : base()
-               {
-                       Icon = new Icon(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "icon.ico"));
+		public Form1() : base()
+		{
+			Icon = new Icon(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "icon.ico"));
 
-                       scaleFactor = DeviceDpi / 96f;
-                       isHighDpi = scaleFactor > 1f;
-                       highlightThickness = isHighDpi ? 5 : 2;
+			scaleFactor = DeviceDpi / 96f;
+			isHighDpi = scaleFactor > 1f;
+			highlightThickness = isHighDpi ? 5 : 2;
 
-                       SetStyle(
-                               ControlStyles.ResizeRedraw
-                         | ControlStyles.AllPaintingInWmPaint
-                         | ControlStyles.UserPaint
-                       , true);
-                       DoubleBuffered = true;
+			SetStyle(
+					ControlStyles.ResizeRedraw
+			  | ControlStyles.AllPaintingInWmPaint
+			  | ControlStyles.UserPaint
+			, true);
+			DoubleBuffered = true;
 
-                       int headerHeight = isHighDpi ? 60 : 70;
-                       int buttonWidth = isHighDpi ? 90 : 110;
-                       int buttonHeight = isHighDpi ? 40 : 50;
+			int headerHeight = isHighDpi ? 60 : 70;
+			int buttonWidth = isHighDpi ? 90 : 110;
+			int buttonHeight = isHighDpi ? 40 : 50;
 
-                       headerPanel = new Panel
-                       {
-                               Dock = DockStyle.Top,
-                               Height = headerHeight,
-                               BackColor = SystemColors.ControlLight
-                       };
+			headerPanel = new Panel
+			{
+				Dock = DockStyle.Top,
+				Height = headerHeight,
+				BackColor = SystemColors.ControlLight
+			};
 
-                       copyButton = new Button
-                       {
-                               Text = "Copy",
-                               Size = new Size(buttonWidth, buttonHeight),
-                               Location = new Point(10, (headerHeight - buttonHeight) / 2)
-                       };
-                       copyButton.Click += CopyButton_Click;
+			copyButton = new Button
+			{
+				Text = "Copy",
+				Size = new Size(buttonWidth, buttonHeight),
+				Location = new Point(10, (headerHeight - buttonHeight) / 2)
+			};
+			copyButton.Click += CopyButton_Click;
 
-                       saveButton = new Button
-                       {
-                               Text = "Save",
-                               Size = new Size(buttonWidth, buttonHeight),
-                               Location = new Point(100, (headerHeight - buttonHeight) / 2)
-                       };
-                       saveButton.Click += SaveButton_Click;
+			saveButton = new Button
+			{
+				Text = "Save",
+				Size = new Size(buttonWidth, buttonHeight),
+				Location = new Point(100, (headerHeight - buttonHeight) / 2)
+			};
+			saveButton.Click += SaveButton_Click;
 
-                       saveAndCopyPathButton = new Button
-                       {
-                               Text = "Save (copy path)",
-                               Size = new Size(isHighDpi ? 240 : 260, buttonHeight),
-                               Location = new Point(200, (headerHeight - buttonHeight) / 2)
-                       };
+			saveAndCopyPathButton = new Button
+			{
+				Text = "Save (copy path)",
+				Size = new Size(isHighDpi ? 240 : 260, buttonHeight),
+				Location = new Point(200, (headerHeight - buttonHeight) / 2)
+			};
 			saveAndCopyPathButton.Click += SaveAndCopyPathButton_Click;
 
 			headerPanel.Controls.Add(copyButton);
@@ -372,11 +372,11 @@ namespace ScreenGrab
 		{
 			if (capturedImage != null && !dragStartPoint.HasValue)
 			{
-                               // Calculate button positions: center all buttons as a group
-                               int gap = 10;
-                               int groupWidth = copyButton.Width + saveButton.Width + saveAndCopyPathButton.Width + (gap * 2);
-                               int leftStart = (ClientSize.Width - groupWidth) / 2;
-                               int top = (headerPanel.Height - copyButton.Height) / 2;
+				// Calculate button positions: center all buttons as a group
+				int gap = 10;
+				int groupWidth = copyButton.Width + saveButton.Width + saveAndCopyPathButton.Width + (gap * 2);
+				int leftStart = (ClientSize.Width - groupWidth) / 2;
+				int top = (headerPanel.Height - copyButton.Height) / 2;
 
 				copyButton.Visible = true;
 				saveButton.Visible = true;
@@ -385,9 +385,9 @@ namespace ScreenGrab
 				saveButton.BringToFront();
 				saveAndCopyPathButton.BringToFront();
 
-                               copyButton.Location = new Point(leftStart, top);
-                               saveButton.Location = new Point(leftStart + copyButton.Width + gap, top);
-                               saveAndCopyPathButton.Location = new Point(leftStart + copyButton.Width + saveButton.Width + (gap * 2), top);
+				copyButton.Location = new Point(leftStart, top);
+				saveButton.Location = new Point(leftStart + copyButton.Width + gap, top);
+				saveAndCopyPathButton.Location = new Point(leftStart + copyButton.Width + saveButton.Width + (gap * 2), top);
 			}
 
 			if (e.Button == MouseButtons.Left && dragStartPoint.HasValue)

--- a/ScreenGrab/ScreenGrab.csproj
+++ b/ScreenGrab/ScreenGrab.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ApplicationIcon>icon.ico</ApplicationIcon>
   </PropertyGroup>
 

--- a/ScreenGrab/ScreenGrab.csproj
+++ b/ScreenGrab/ScreenGrab.csproj
@@ -1,31 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
-    <Nullable>enable</Nullable>
-    <UseWindowsForms>true</UseWindowsForms>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
-    <ApplicationIcon>icon.ico</ApplicationIcon>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<TargetFramework>net9.0-windows</TargetFramework>
+		<Nullable>enable</Nullable>
+		<UseWindowsForms>true</UseWindowsForms>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<EnableWindowsTargeting>true</EnableWindowsTargeting>
+		<ApplicationIcon>icon.ico</ApplicationIcon>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>embedded</DebugType>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DebugType>embedded</DebugType>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="icon.ico" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="icon.ico" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Content Include="icon.ico">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="icon.ico">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- adapt UI element sizes based on DPI
- thin highlight rectangles on low‑DPI screens
- allow building on non‑Windows containers

## Testing
- `dotnet build ScreenGrab/ScreenGrab.csproj -c Release` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_b_68768a3c2cbc8322a2c8abfaf6c29920